### PR TITLE
Oneko Sleeps in different locations on progress bar!

### DIFF
--- a/oneko.js
+++ b/oneko.js
@@ -153,20 +153,9 @@
     const elapsedTimeRight = elapsedTime.getBoundingClientRect().right;
     const elapsedTimeLeft = elapsedTime.getBoundingClientRect().left;
 
-    // If the remaining time is on top right of the progress bar, make the cat sleep to the a little bit to the left of the remaining time
-    // Theme compatibility
-    if (remainingTimeLeft < progressBarRight && remainingTimeTop < progressBarBottom && progressBarTop - remainingTimeBottom < 32) {
-      mousePosX = remainingTimeLeft - 16;
-
-      // Comfy special case
-      if (Spicetify.Config.current_theme === "Comfy") {
-        mousePosY = progressBarTop - 14;
-      }
-
-      // Move the cat to the left of elapsed time if it is too close to the remaining time (Nord theme)
-      if (remainingTimeLeft - elapsedTimeRight < 32) {
-        mousePosX = elapsedTimeLeft - 16;
-      }
+    // Comfy special case
+    if (Spicetify.Config.current_theme === "Comfy") {
+      mousePosY = progressBarTop - 14;
     }
   }
 

--- a/oneko.js
+++ b/oneko.js
@@ -11,6 +11,7 @@
     idleAnimation = null,
     idleAnimationFrame = 0,
     forceSleep = false,
+    sleepSaved = true,
     grabbing = false,
     grabStop = true,
     nudge = false,
@@ -124,10 +125,22 @@
     const progressBarTop = progressBar.getBoundingClientRect().top;
     const progressBarBottom = progressBar.getBoundingClientRect().bottom;
 
-    // Make the cat sleep on the progress bar
+    const progressBarWidth = progressBarRight - progressBarLeft;
     // Clamps position to closest point from mouse to bar
-    mousePosX = Math.min(Math.max(progressBarLeft + 16, mousePosX), progressBarRight - 16);
+    const normalizedSleepLocation = Math.min(Math.max(progressBarLeft + 16, mousePosX), progressBarRight - 16);
+    const percentSleepLocation = (normalizedSleepLocation - progressBarLeft) / progressBarWidth;
+    // Make the cat sleep on the progress bar
+    // if there is a saved location, go there
+    mousePosX = sleepSaved ?
+      progressBarLeft + (parseLocalStorage("sleepPos", 0) * progressBarWidth) :
+      normalizedSleepLocation;
     mousePosY = progressBarTop - 8;
+
+    //save sleeping location
+    if (!sleepSaved) {
+      localStorage.setItem("oneko:sleepPos", percentSleepLocation);
+      sleepSaved = true;
+    }
 
     // Get the position of the remaining time
     const remainingTime = document.querySelector(".main-playbackBarRemainingTime-container");
@@ -255,7 +268,11 @@
       nekoEl.style.filter = kuroNeko ? "invert(100%)" : "none";
     });
 
-    nekoEl.addEventListener("dblclick", sleep);
+    // on new sleep, reset saved position
+    nekoEl.addEventListener("dblclick", () => {
+      sleepSaved = false;
+      sleep()
+    });
 
     window.onekoInterval = setInterval(frame, 100);
   }

--- a/oneko.js
+++ b/oneko.js
@@ -249,12 +249,17 @@
         nekoEl.style.top = `${nekoPosY - 16}px`;
       };
 
-      const mouseup = () => {
+      const mouseup = (e) => {
         grabbing = false;
         nudge = true;
         resetIdleAnimation();
         window.removeEventListener("mousemove", mousemove);
         window.removeEventListener("mouseup", mouseup);
+        // Refresh sleeping position when dragged away
+        mousePosX = e.clientX;
+        sleepSaved = false;
+        forceSleep = false;
+        sleep();
       };
 
       window.addEventListener("mousemove", mousemove);

--- a/oneko.js
+++ b/oneko.js
@@ -245,10 +245,12 @@
         window.removeEventListener("mousemove", mousemove);
         window.removeEventListener("mouseup", mouseup);
         // Refresh sleeping position when dragged away
-        mousePosX = e.clientX;
-        sleepSaved = false;
-        forceSleep = false;
-        sleep();
+        if (forceSleep) {
+          mousePosX = e.clientX;
+          sleepSaved = false;
+          forceSleep = false;
+          sleep();
+        }
       };
 
       window.addEventListener("mousemove", mousemove);

--- a/oneko.js
+++ b/oneko.js
@@ -120,11 +120,13 @@
     // Get the far right and top of the progress bar
     const progressBar = document.querySelector(".main-nowPlayingBar-center .playback-progressbar");
     const progressBarRight = progressBar.getBoundingClientRect().right;
+    const progressBarLeft = progressBar.getBoundingClientRect().left;
     const progressBarTop = progressBar.getBoundingClientRect().top;
     const progressBarBottom = progressBar.getBoundingClientRect().bottom;
 
     // Make the cat sleep on the progress bar
-    mousePosX = progressBarRight - 16;
+    // Clamps position to closest point from mouse to bar
+    mousePosX = Math.min(Math.max(progressBarLeft + 16, mousePosX), progressBarRight - 16);
     mousePosY = progressBarTop - 8;
 
     // Get the position of the remaining time


### PR DESCRIPTION
Oneko now sleeps in the closest point on the bar! 
As in if she is to the left, she sleeps on the left side, if she is in the middle, she sleeps in the middle, etc.
This somewhat addresses #2 
Gif demonstration:
![Screencast from 2025-02-10 10-36-18](https://github.com/user-attachments/assets/e801796b-b9aa-442a-a1bf-82103cc906ca)
<sub> apologies for the terrible quality </sub>